### PR TITLE
Added contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing to Projector
+Thank you for reading this: we welcome any contributions.
+
+All Projector-related projects have the same contributing guidelines. The place where they are described
+is [documentation](https://jetbrains.github.io/projector-client/mkdocs/latest/about/contributing/).


### PR DESCRIPTION
Copied CONTRIBUTING.md from projector-client.

I saw you have it there and not here, and it would make it easier for users to find the full guidelines.